### PR TITLE
[WIP] Update to using metadata file

### DIFF
--- a/neopixel.meta
+++ b/neopixel.meta
@@ -1,0 +1,35 @@
+{
+  "0": {
+    "llType": "error",
+    "columns": [
+      {
+        "llabel": "error message",
+        "dtype": "str"
+      }
+    ]
+  },
+  "1": {
+    "llType": "data",
+    "columns": [
+      {
+        "llabel": "pixels",
+        "dtype": "int"
+      },
+      {
+        "llabel": "red",
+        "detail": "Red LED Value",
+        "dtype": "int"
+      },
+      {
+        "llabel": "green",
+        "detail": "Green LED Value",
+        "dtype": "int"
+      },
+      {
+        "llabel": "blue",
+        "detail": "Blue LED Value",
+        "dtype": "int"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Part of https://github.com/bluerobotics/navigator-validation/issues/5

I've put it as `pixels (int) | red (int) | green (int) | blue (int)`, but we can change to a single string column for the colour tuple later if desired.

We may also need to do something a bit more involved if we want to track the individual pixel colours (the existing test just sets them all to the same colour, but not sure if that's going to necessarily stay that way)